### PR TITLE
Update communityRules.json

### DIFF
--- a/communityRules.json
+++ b/communityRules.json
@@ -8216,13 +8216,6 @@
             }
         },
         "shavius.dynamicdiplomacy.zh": {
-            "loadBefore": {
-                "nilchei.dynamicdiplomacy": {
-                    "name": [
-                        "Dynamic Diplomacy"
-                    ]
-                }
-            },
             "loadAfter": {
                 "nilchei.dynamicdiplomacy": {
                     "comment": [


### PR DESCRIPTION
shavius's translation for the mod dynamic diplomacy has a community rule to load before and after the actual mod, which causes a circular dependency issue.

Erasing the load before rules so the translation is loaded after the actual mod.