### PR TITLE
Adding rules to fix load-order based errors.

### DIFF
--- a/communityRules.json
+++ b/communityRules.json
@@ -11347,6 +11347,38 @@
                     "name": "Zoroark - Illusion Pokemon [1.5]"
                 }
             }
+        },
+        "telardo.multifloors": {
+            "loadAfter": {
+                "vanillaexpanded.vtexe": {
+                    "comment": "Vanilla Textures Expanded breaks the Floors tab UI if MultiFloors is loaded before VTE.",
+                    "name": "Vanilla Textures Expanded"
+                }
+            }
+        },
+        "oskarpotocki.vanillavehiclesexpanded": {
+            "loadAfter": {
+                "biomesteam.biomescaverns": {
+                    "comment": "Breaks World Generation and World Loading in general if this is loaded prior to the various Biomes! mods.",
+                    "name": "Biomes! Caverns"
+                },
+                "biomesteam.biomescore": {
+                    "comment": "Breaks World Generation and World Loading in general if this is loaded prior to the various Biomes! mods.",
+                    "name": "Biomes! Core"
+                },
+                "biomesteam.biomesfossils": {
+                    "comment": "Breaks World Generation and World Loading in general if this is loaded prior to the various Biomes! mods.",
+                    "name": "Biomes! Fossils"
+                },
+                "biomesteam.biomesislands": {
+                    "comment": "Breaks World Generation and World Loading in general if this is loaded prior to the various Biomes! mods.",
+                    "name": "Biomes! Islands"
+                },
+                "biomesteam.oasis": {
+                    "comment": "Breaks World Generation and World Loading in general if this is loaded prior to the various Biomes! mods.",
+                    "name": "Biomes! Oasis"
+                }
+            }
         }
     }
 }

--- a/communityRules.json
+++ b/communityRules.json
@@ -1,6 +1,6 @@
 {
 
-    "timestamp": 1726659082,
+    "timestamp": 1735715266,
 
     "rules": {
         "3tes.cgtwaa": {


### PR DESCRIPTION
Vanilla Textures Expanded breaks MultiFloors's Floor tab UI if loaded after it. MultiFloors's Floor tab UI works properly when loaded after VTE.

For some reason, Vanilla Vehicles Expanded breaks any attempt to load the planet itself (both for world gen and when loading a save) if it is loaded before the "Biomes!" mods.