### PR TITLE
Fix black screen with High Quality Textures and Vanilla Textures Expanded

### DIFF
--- a/communityRules.json
+++ b/communityRules.json
@@ -1,6 +1,6 @@
 {
 
-    "timestamp": 1735715266,
+    "timestamp": 1737746012,
 
     "rules": {
         "3tes.cgtwaa": {
@@ -1517,6 +1517,14 @@
                     "name": [
                         "Vanilla Factions Expanded - Classical"
                     ]
+                }
+            }
+        },
+        "chad.highqualitytextures1.5": {
+            "loadAfter": {
+                "vanillaexpanded.vtexe": {
+                    "comment": "Error during loading -> black screen",
+                    "name": "Vanilla Textures Expanded"
                 }
             }
         },


### PR DESCRIPTION
If High Quality Textures is loaded before Vanilla Textures Expanded patching will error early. After that the screen is black, though the game continues to load. The screen stays black forever.