### PR TITLE
Adds sorting rules for temporary Ratkin Solaris mod

### DIFF
--- a/communityRules.json
+++ b/communityRules.json
@@ -1,5 +1,5 @@
 {
-    "timestamp": 1754456621,
+    "timestamp": 1754823348,
     "rules": {
         "3tes.cgtwaa": {
             "loadAfter": {
@@ -11622,6 +11622,50 @@
                 "usagirei.lootgoblin": {
                     "comment": "Overlapping functionality",
                     "name": "Loot Goblin"
+                }
+            }
+        },
+        "fxz.solaris.ratkinracemod.odyssey": {
+            "loadBefore": {
+                "bbb.ratkinweapon.morefailure": {
+                    "comment": "Add sorting rules for the temporary version",
+                    "name": "Ratkin Weapons+"
+                },
+                "fxz.ratkin.facialanimation": {
+                    "comment": "Add sorting rules for the temporary version",
+                    "name": "Hyacinth's Ratkin Facial Animation"
+                },
+                "fxz.ratkinfaction": {
+                    "comment": "Add sorting rules for the temporary version",
+                    "name": "Ratkin Faction+"
+                },
+                "momanacha.ratkinbodyretexture": {
+                    "comment": "Add sorting rules for the temporary version",
+                    "name": "Ratkin Body Retexture"
+                },
+                "momanacha.rkhairexpanded": {
+                    "comment": "Add sorting rules for the temporary version",
+                    "name": "Ratkin Hairstyle Expanded"
+                },
+                "oark.ratkinfaction.geneexpand": {
+                    "comment": "Add sorting rules for the temporary version",
+                    "name": "[OA]Ratkin Gene Expand"
+                },
+                "oark.ratkinfaction.oberoniaaurea": {
+                    "comment": "Add sorting rules for the temporary version",
+                    "name": "[OA]Ratkin Faction: Oberonia aurea"
+                },
+                "oark.ratkinfaction.scenarioexpand.snowstorm": {
+                    "comment": "Add sorting rules for the temporary version",
+                    "name": "[OA]Ratkin Scenario: Snowstorm Orphan"
+                },
+                "oark.ratkinknightorderfurniture": {
+                    "comment": "Add sorting rules for the temporary version",
+                    "name": "[OA]Ratkin : Knight Order(Furniture)"
+                },
+                "thewwworld.ratkinnameplus": {
+                    "comment": "Add sorting rules for the temporary version",
+                    "name": "\u9f20\u65cf\u540d\u79f0\u6269\u5c55RatkinNamePlus"
                 }
             }
         }


### PR DESCRIPTION
Introduces load order rules to improve compatibility between the temporary Ratkin Solaris mod and related mods.
Helps prevent conflicts and ensures correct mod sequencing.