### PR TITLE
ci: Add a workflow to do a basic JSON syntax check

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,23 @@
+name: QA
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  validate-json:
+    name: Validate JSON syntax
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate JSON syntax
+        run: python -m json.tool communityRules.json > /dev/null


### PR DESCRIPTION
Create a workflow to do a basic JSON syntax check.

This should catch the basic stuff, though it won't ensure that it doesn't break the schema that RimSort is expecting. The inclusion of this in the repo shouldn't cause issues with RimSort itself.